### PR TITLE
Fix nanosleep

### DIFF
--- a/src/syscall/timer.c
+++ b/src/syscall/timer.c
@@ -62,7 +62,7 @@ DEFINE_SYSCALL(nanosleep, const struct timespec *, req, struct timespec *, rem)
 	if (!mm_check_read(req, sizeof(struct timespec)) || rem && !mm_check_write(rem, sizeof(struct timespec)))
 		return -EFAULT;
 	LARGE_INTEGER delay_interval;
-	delay_interval.QuadPart = ((uint64_t)req->tv_sec * 1000000000ULL + req->tv_nsec) / 100ULL;
+	delay_interval.QuadPart = 0ULL - (((uint64_t)req->tv_sec * 1000000000ULL + req->tv_nsec) / 100ULL);
 	NtDelayExecution(FALSE, &delay_interval);
 	return 0;
 }


### PR DESCRIPTION
nanosleep is implemented with NtDelayExecution, but to have a relative delay the sleep time must be negated.
