### PR TITLE
Add *.VC.opendb files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ _Chutzpah*
 ipch/
 *.aps
 *.ncb
+*.VC.opendb
 *.opensdf
 *.sdf
 *.cachefile


### PR DESCRIPTION
These files are generated by Visual Studio 2015 Update 1 and are present when you have a solution containing a C++ project open for editing. They are automatically deleted when you close the solution. I found that adding this pattern to the gitignore makes development easier, as I no longer have to close Visual Studio every time I commit.
