### PR TITLE
Add support for /dev/zero

### DIFF
--- a/flinux.vcxproj
+++ b/flinux.vcxproj
@@ -78,6 +78,7 @@
     <ClInclude Include="src\fs\sysfs.h" />
     <ClInclude Include="src\fs\virtual.h" />
     <ClInclude Include="src\fs\winfs.h" />
+    <ClInclude Include="src\fs\zero.h" />
     <ClInclude Include="src\heap.h" />
     <ClInclude Include="src\lib\core.h" />
     <ClInclude Include="src\lib\list.h" />
@@ -128,6 +129,7 @@
     <ClCompile Include="src\fs\random.c" />
     <ClCompile Include="src\fs\socket.c" />
     <ClCompile Include="src\fs\winfs.c" />
+    <ClCompile Include="src\fs\zero.c" />
     <ClCompile Include="src\heap.c" />
     <ClCompile Include="src\lib\rbtree.c" />
     <ClCompile Include="src\log.c" />

--- a/flinux.vcxproj.filters
+++ b/flinux.vcxproj.filters
@@ -258,6 +258,9 @@
     <ClInclude Include="src\flags.h" />
     <ClInclude Include="src\win7compat.h" />
     <ClInclude Include="src\shared.h" />
+    <ClInclude Include="src\fs\zero.h">
+      <Filter>fs</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\main.c" />
@@ -361,6 +364,9 @@
     <ClCompile Include="src\flags.c" />
     <ClCompile Include="src\win7compat.c" />
     <ClCompile Include="src\shared.c" />
+    <ClCompile Include="src\fs\zero.c">
+      <Filter>fs</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <MASM Include="src\syscall\stubs64.asm">

--- a/src/fs/devfs.c
+++ b/src/fs/devfs.c
@@ -31,7 +31,7 @@ static const struct virtualfs_directory_desc devfs =
 	.entries = {
 		VIRTUALFS_ENTRY("dsp", dsp_desc)
 		VIRTUALFS_ENTRY("null", null_desc)
-	    VIRTUALFS_ENTRY("zero", zero_desc)
+		VIRTUALFS_ENTRY("zero", zero_desc)
 		VIRTUALFS_ENTRY("random", random_desc)
 		VIRTUALFS_ENTRY("urandom", urandom_desc)
 		VIRTUALFS_ENTRY("console", console_desc)

--- a/src/fs/zero.c
+++ b/src/fs/zero.c
@@ -17,30 +17,17 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <fs/console.h>
-#include <fs/devfs.h>
-#include <fs/dsp.h>
-#include <fs/null.h>
-#include <fs/random.h>
-#include <fs/virtual.h>
 #include <fs/zero.h>
 
-static const struct virtualfs_directory_desc devfs =
+static size_t zero_read(int tag, void *buf, size_t count)
 {
-	.type = VIRTUALFS_TYPE_DIRECTORY,
-	.entries = {
-		VIRTUALFS_ENTRY("dsp", dsp_desc)
-		VIRTUALFS_ENTRY("null", null_desc)
-	    VIRTUALFS_ENTRY("zero", zero_desc)
-		VIRTUALFS_ENTRY("random", random_desc)
-		VIRTUALFS_ENTRY("urandom", urandom_desc)
-		VIRTUALFS_ENTRY("console", console_desc)
-		VIRTUALFS_ENTRY("tty", console_desc)
-		VIRTUALFS_ENTRY_END()
-	}
-};
-
-struct file_system *devfs_alloc()
-{
-	return virtualfs_alloc("/dev", &devfs);
+	RtlZeroMemory(buf, count);
+	return count;
 }
+
+static size_t zero_write(int tag, const void *buf, size_t count)
+{
+	return count;
+}
+
+struct virtualfs_char_desc zero_desc = VIRTUALFS_CHAR(mkdev(1, 10), zero_read, zero_write);

--- a/src/fs/zero.c
+++ b/src/fs/zero.c
@@ -30,4 +30,4 @@ static size_t zero_write(int tag, const void *buf, size_t count)
 	return count;
 }
 
-struct virtualfs_char_desc zero_desc = VIRTUALFS_CHAR(mkdev(1, 10), zero_read, zero_write);
+struct virtualfs_char_desc zero_desc = VIRTUALFS_CHAR(mkdev(1, 5), zero_read, zero_write);

--- a/src/fs/zero.h
+++ b/src/fs/zero.h
@@ -17,30 +17,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <fs/console.h>
-#include <fs/devfs.h>
-#include <fs/dsp.h>
-#include <fs/null.h>
-#include <fs/random.h>
+#pragma once
+
 #include <fs/virtual.h>
-#include <fs/zero.h>
 
-static const struct virtualfs_directory_desc devfs =
-{
-	.type = VIRTUALFS_TYPE_DIRECTORY,
-	.entries = {
-		VIRTUALFS_ENTRY("dsp", dsp_desc)
-		VIRTUALFS_ENTRY("null", null_desc)
-	    VIRTUALFS_ENTRY("zero", zero_desc)
-		VIRTUALFS_ENTRY("random", random_desc)
-		VIRTUALFS_ENTRY("urandom", urandom_desc)
-		VIRTUALFS_ENTRY("console", console_desc)
-		VIRTUALFS_ENTRY("tty", console_desc)
-		VIRTUALFS_ENTRY_END()
-	}
-};
-
-struct file_system *devfs_alloc()
-{
-	return virtualfs_alloc("/dev", &devfs);
-}
+struct virtualfs_char_desc zero_desc;


### PR DESCRIPTION
I copied the code for `/dev/null` and modified it to work as expected for `/dev/zero`. Tested with `dd if=/dev/zero of=/tmp/zero.file bs=1k count=1` and verified working.

**Please note:** My choice of major 1/minor 10 for the zero device is purely a best guess. Most likely, this will break some Linux application somewhere. If you have a better idea of what the major and minor should be for this device file, please let me know.
